### PR TITLE
fix: use official PostgreSQL image instead of bitnami one

### DIFF
--- a/ansible/roles/docker/files/docker-compose.yaml
+++ b/ansible/roles/docker/files/docker-compose.yaml
@@ -8,7 +8,7 @@ networks:
 
 services:
   database:
-    image: 'bitnami/postgresql:17'
+    image: 'postgres:17'
     hostname: 'database.internal'
     restart: unless-stopped
     environment:

--- a/docker-compose/docker-compose-local.yaml
+++ b/docker-compose/docker-compose-local.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   database:
-    image: 'bitnami/postgresql:17'
+    image: 'postgres:17'
     hostname: 'database.internal'
     restart: unless-stopped
     environment:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -8,7 +8,7 @@ networks:
 
 services:
   database:
-    image: 'bitnami/postgresql:17'
+    image: 'postgres:17'
     hostname: 'database.internal'
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Bitnami are taking down their images and moving them behind a paywall. See [this](https://github.com/bitnami/containers?tab=readme-ov-file#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog) for more information.